### PR TITLE
Copy special attributes to descriptor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,3 +44,7 @@ norecursedirs = build dist
 testpaths =
     fallback_property
     tests
+
+
+[mypy]
+ignore_missing_imports = True

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -9,8 +9,6 @@ class Product:
     def _total(self):
         return self.units * self.price
 
-    # TOOO fix mypy error
-    #      possible solution: https://github.com/python/mypy/issues/1551#issuecomment-253978622  # NOQA
     @fallback_property()
     def total(self):
         return self._total()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -9,6 +9,8 @@ class Product:
     def _total(self):
         return self.units * self.price
 
+    # TOOO fix mypy error
+    #      possible solution: https://github.com/python/mypy/issues/1551#issuecomment-253978622  # NOQA
     @fallback_property()
     def total(self):
         return self._total()
@@ -103,3 +105,33 @@ def test_fallback_property__logging(caplog):
     product.total_with_logging
     assert 'without prefetched value.' in caplog.text
     assert 'Product.total_with_logging' in caplog.text
+
+
+def test_use_like_property():
+    """
+    Use as a function should be possible.
+    """
+    class Foo:
+        @fallback_property
+        def bar(self):
+            """
+            Test.
+            """
+            return 1
+
+    assert Foo().bar == 1
+
+
+def test_use_as_function():
+    """
+    Use as a function should be possible.
+    """
+    class Foo:
+        def _bar(self):
+            """
+            Test.
+            """
+            return 1
+        bar = fallback_property(_bar, logging=False)
+
+    assert Foo().bar == 1

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,4 +1,7 @@
 import pytest
+from django.contrib.admin.utils import label_for_field
+
+from fallback_property import FallbackDescriptor, fallback_property
 
 from . import models
 
@@ -24,3 +27,41 @@ def test_fallback_property(pipeline, django_assert_num_queries):
     pipeline = models.Pipeline.objects.with_total_length().get(pk=pipeline.pk)
     with django_assert_num_queries(0):
         assert pipeline.total_length == TOTAL_LENGTH
+
+
+def test_admin_special_properties():
+    """
+    Copy special attribute to the decorator.
+
+    The django `ModelAdmin` uses special attributes to alter the behaviour of a
+    property/method displayed in the admin.
+    """
+    from django.db import models as django_models
+
+    BOOLEAN = True
+    EMPTY = 'empty'
+    LABEL = "LABEL"
+    ORDER_VALUE = 'foo_bar'
+
+    class Foo(django_models.Model):
+        def _bar(self):
+            """
+            Test.
+            """
+            return 1
+        _bar.admin_order_value = ORDER_VALUE
+        _bar.boolean = BOOLEAN
+        _bar.empty_value_display = EMPTY
+        _bar.short_description = LABEL
+        bar = fallback_property(_bar, logging=False)
+
+    descriptor = getattr(Foo, 'bar')
+    assert isinstance(descriptor, FallbackDescriptor)
+
+    assert descriptor.admin_order_value == ORDER_VALUE
+    assert descriptor.boolean == BOOLEAN
+    assert descriptor.empty_value_display == EMPTY
+    assert descriptor.short_description == LABEL
+
+    # Django should be able to extract the label
+    assert label_for_field('bar', Foo) == LABEL

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,1 +1,3 @@
-urlpatterns = []
+from typing import Any, List
+
+urlpatterns: List[Any] = []


### PR DESCRIPTION
In order to make some Django functionalities to work, we have to copy some attributes to the descriptor.